### PR TITLE
BODMAS logic fixed

### DIFF
--- a/core_logic.py
+++ b/core_logic.py
@@ -61,28 +61,25 @@ class Calculate():
                     new_instance.calculate()
                     ]
 
-        exponent = self.__operators[1]
-        while exponent in self.expr_as_list:
-            index = self.expr_as_list.index(exponent)
-            self.__partial_calculate(index)
+        exp_op = self.__operators[1]
+        gen_exp = (g for g in exp_op if g in self.expr_as_list)
+        if any(gen_exp):
+            self.__call_partial_calculate(exp_op)
 
         div_mul_op = self.__operators[2:4]
         gen_mul_div = (g for g in div_mul_op if g in self.expr_as_list)
-        while any(gen_mul_div):
-            index = self.expr_as_list.index(self.__operators[1])
-            self.__partial_calculate(index)
+        if any(gen_mul_div):
+            self.__call_partial_calculate(div_mul_op)
 
         add_sub_op = self.__operators[4:6]
         gen_add_sub = (g for g in add_sub_op if g in self.expr_as_list)
-        while any(gen_add_sub):
-            index = self.expr_as_list.index(self.__operators[3])
-            self.__partial_calculate(index)
+        if any(gen_add_sub):
+            self.__call_partial_calculate(add_sub_op)
 
-        self.ans = self.expr_as_list[0]
-        return self.ans
+        self.ans = self.expr_as_list
+        return self.ans[0]
 
     def __partial_calculate(self, index: int) -> None:
-        print(self.expr_as_list)
         """Computes single chunk of expression from provided operator index
 
         From given operator index, left and right operand index assumes index-1
@@ -119,3 +116,11 @@ class Calculate():
             expression.extend(right_paren * count_diff)
             return expression
         return expression
+
+    def __call_partial_calculate(self, operator):
+        while True:
+            indices = (i for i, e in enumerate(self.expr_as_list) if
+                       e in operator)
+            index = next(indices, False)
+            if not index: break
+            self.__partial_calculate(index)

--- a/core_logic.py
+++ b/core_logic.py
@@ -62,17 +62,17 @@ class Calculate():
                     ]
 
         exp_op = self.__operators[1]
-        gen_exp = (g for g in exp_op if g in self.expr_as_list)
+        gen_exp = self.__create_op_gen(exp_op)
         if any(gen_exp):
             self.__call_partial_calculate(exp_op)
 
         div_mul_op = self.__operators[2:4]
-        gen_mul_div = (g for g in div_mul_op if g in self.expr_as_list)
+        gen_mul_div = self.__create_op_gen(div_mul_op)
         if any(gen_mul_div):
             self.__call_partial_calculate(div_mul_op)
 
         add_sub_op = self.__operators[4:6]
-        gen_add_sub = (g for g in add_sub_op if g in self.expr_as_list)
+        gen_add_sub = self.__create_op_gen(add_sub_op)
         if any(gen_add_sub):
             self.__call_partial_calculate(add_sub_op)
 
@@ -124,3 +124,7 @@ class Calculate():
             index = next(indices, False)
             if not index: break
             self.__partial_calculate(index)
+
+    def __create_op_gen(self, operator: list):
+        generator = (g for g in operator if g in self.expr_as_list)
+        return generator

--- a/core_logic.py
+++ b/core_logic.py
@@ -49,39 +49,40 @@ class Calculate():
         expr_as_list[0] is returned.
         """
 
-        while self.__operators[0] in self.expr_as_list:
+        left_paren = self.__operators[0]
+        while left_paren in self.expr_as_list:
             expression = self.__bracket_balencer(self.expr_as_list.copy())
             left_p = expression.index('(')
-            if ')' not in self.expr_as_list:
-                self.expr_as_list.pop(left_p)
-            else:
-                right_p = (len(expression)
-                           - list(reversed(expression)).index(')') - 1)
-                sub_expression = expression[left_p+1:right_p]
-                new_instance = Calculate(sub_expression)
-                self.expr_as_list[left_p:right_p+1] = [
-                        new_instance.calculate()
-                        ]
+            right_p = (len(expression)
+                       - list(reversed(expression)).index(')') - 1)
+            sub_expression = expression[left_p+1:right_p]
+            new_instance = Calculate(sub_expression)
+            self.expr_as_list[left_p:right_p+1] = [
+                    new_instance.calculate()
+                    ]
 
-        while self.__operators[1] in self.expr_as_list:
+        exponent = self.__operators[1]
+        while exponent in self.expr_as_list:
+            index = self.expr_as_list.index(exponent)
+            self.__partial_calculate(index)
+
+        div_mul_op = self.__operators[2:4]
+        gen_mul_div = (g for g in div_mul_op if g in self.expr_as_list)
+        while any(gen_mul_div):
             index = self.expr_as_list.index(self.__operators[1])
             self.__partial_calculate(index)
-        while self.__operators[2] in self.expr_as_list:
-            index = self.expr_as_list.index(self.__operators[2])
-            self.__partial_calculate(index)
-        while self.__operators[3] in self.expr_as_list:
+
+        add_sub_op = self.__operators[4:6]
+        gen_add_sub = (g for g in add_sub_op if g in self.expr_as_list)
+        while any(gen_add_sub):
             index = self.expr_as_list.index(self.__operators[3])
             self.__partial_calculate(index)
-        while self.__operators[4] in self.expr_as_list:
-            index = self.expr_as_list.index(self.__operators[4])
-            self.__partial_calculate(index)
-        while self.__operators[5] in self.expr_as_list:
-            index = self.expr_as_list.index(self.__operators[5])
-            self.__partial_calculate(index)
+
         self.ans = self.expr_as_list[0]
         return self.ans
 
     def __partial_calculate(self, index: int) -> None:
+        print(self.expr_as_list)
         """Computes single chunk of expression from provided operator index
 
         From given operator index, left and right operand index assumes index-1

--- a/test/test_core_logic.py
+++ b/test/test_core_logic.py
@@ -27,11 +27,23 @@ class CoreLogicTests(unittest.TestCase):
 
         self.assertEqual(result, "10.0")
 
+    def test_parenthesis_precedence_2(self):
+        test_case_input = ['6', '/', '(', '4', '+', '2', ')']
+        result = self.go_for_testing(test_case_input)
+
+        self.assertEqual(result, "1.0")
+
     def test_bracket_balencer(self):
         test_case_input = ['(', '3', '*', '(', '4', '+', '1']
         result = self.go_for_testing(test_case_input)
 
         self.assertEqual(result, "15.0")
+
+    def test_bodmas(self):
+        test_case_input = ['44', '-', '3', '/', '6', '+', '2', '*', '2']
+        result = self.go_for_testing(test_case_input)
+
+        self.assertEqual(result, "47.5")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### This PR fixes a fatal BODMAS logic error. BODMAS operator precedence goes like this:
 - Calculate elements inside the parenthesis first.
 - Evaluate orders/powers next.
 - Multiplication and Division have equal precedence next. Evaluate them from left to right. 
 - Addition and subtraction have equal precedence next. Evaluate them from left to right.

#### Logic before this PR evaluated expressions in the following order:
 - Parenthesis
 - Orders
 - Division
 - Multiplication
 - Addition
 - Subtraction

Though there seems to be no mistake with Division and Multiplication precedence, giving priority to addition over subtraction make a significant mistake in calculation. Test case `test_bodmas` in *test_core_logic.py* shows this difference. 
For example, refer following evaluated result before and after this PR:
> 4 - 3 + 2
Ans: -1.0

> 4 - 3 + 2 
Ans: 3.0